### PR TITLE
Update 68KMLA URL in readme to a good link

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,4 +73,4 @@ Contributing
 
 This is a work in progress. Emails, forum posts, patches and pull requests welcome! I have started a discussion on the 68kMLA forum:
 
-https://68kmla.org/forums/index.php?/topic/59570-backporting-hfs-to-mac-os-80-and-earlier/
+https://68kmla.org/bb/index.php?threads/backporting-hfs-to-mac-os-8-0-and-earlier.35742/


### PR DESCRIPTION
The previous link to the thread was for the old forum, back when it was running a previous flavor of forum software. The old URLs don't point/redirect to the new ones.